### PR TITLE
fix(settings): remove duplicate Gantt view configuration

### DIFF
--- a/src/common/setting-definition.ts
+++ b/src/common/setting-definition.ts
@@ -520,21 +520,6 @@ export const DEFAULT_SETTINGS: TaskProgressBarSettings = {
 				useMarkdownRenderer: true,
 			} as GanttSpecificConfig,
 		},
-		{
-			id: "gantt",
-			name: t("Plan"),
-			icon: "chart-gantt",
-			type: "default",
-			visible: true,
-			hideCompletedAndAbandonedTasks: false,
-			filterRules: {},
-			filterBlanks: false,
-			specificConfig: {
-				viewType: "gantt",
-				showTaskLabels: true,
-				useMarkdownRenderer: true,
-			} as GanttSpecificConfig,
-		},
 	],
 
 	// Review Settings


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/91c30d04-c5a1-4d3c-a5a2-d40d22b592b4)

这两段重复了……这就是之前导致双「计划」的罪魁祸首：
![image](https://github.com/user-attachments/assets/786f520a-8cc7-4587-951b-dbcaf9a36af3)
